### PR TITLE
Update API URI

### DIFF
--- a/scripts/data_pipeline.ts
+++ b/scripts/data_pipeline.ts
@@ -201,7 +201,7 @@ export function extend(defaults: { [key: string]: any }, updates: { [key: string
 }
 
 async function main() {
-  let dataUrl = 'https://twofactorauth.org/data.json';
+  let dataUrl = 'https://twofactorauth.org/api/v1/data.json';
 
   try {
     let res = await fetch(dataUrl);


### PR DESCRIPTION
twofactorauth.org moved the URI for our API a while back. While the old URI still works it's probably best to use the most recent URI just in case the 301 redirect would cease to work in the future.